### PR TITLE
Add undo history, advanced search, merge tracking, and split groups

### DIFF
--- a/src/app/analytics/advanced/page.jsx
+++ b/src/app/analytics/advanced/page.jsx
@@ -164,7 +164,7 @@ export default function AdvancedSearchPage() {
         <div
           style={{
             display: "grid",
-            gridTemplateColumns: "1fr 1fr",
+            gridTemplateColumns: "repeat(auto-fit, minmax(200px, 1fr))",
             gap: 12,
           }}
         >

--- a/src/app/analytics/page.jsx
+++ b/src/app/analytics/page.jsx
@@ -622,7 +622,7 @@ export default function AnalyticsPage() {
             padding: 14,
             display: "grid",
             gap: 12,
-            gridTemplateColumns: "1fr 1fr",
+            gridTemplateColumns: "repeat(auto-fit, minmax(280px, 1fr))",
             alignItems: "start",
             borderRadius: 16,
           }}

--- a/src/app/api/state/route.js
+++ b/src/app/api/state/route.js
@@ -151,6 +151,26 @@ export async function PUT(req) {
       return NextResponse.json({ ok: true });
     }
 
+    // Delete a history row (used by undo-finish to clean up after restoring to live)
+    if (op === "DELETE_FROM_HISTORY") {
+      const id = payload?.id;
+      if (!id) {
+        return NextResponse.json(
+          { ok: false, error: "Missing history id." },
+          { status: 400 },
+        );
+      }
+
+      const { error } = await sb
+        .from("ropes_entries_history")
+        .delete()
+        .eq("site_id", siteId)
+        .eq("id", id);
+
+      if (error) throw error;
+      return NextResponse.json({ ok: true });
+    }
+
     /**
      * Move one entry to history (DONE / ARCHIVED)
      */
@@ -206,9 +226,11 @@ export async function PUT(req) {
         merge_history: live.merge_history ?? null,
       };
 
-      const { error: he } = await sb
+      const { data: histInserted, error: he } = await sb
         .from("ropes_entries_history")
-        .insert(historyRow);
+        .insert(historyRow)
+        .select("id")
+        .single();
       if (he) throw he;
 
       const { error: de } = await sb
@@ -219,7 +241,11 @@ export async function PUT(req) {
 
       if (de) throw de;
 
-      return NextResponse.json({ ok: true });
+      return NextResponse.json({
+        ok: true,
+        history_id: histInserted?.id || null,
+        live_snapshot: live,
+      });
     }
 
     /**

--- a/src/app/components/ropes/Topbar.jsx
+++ b/src/app/components/ropes/Topbar.jsx
@@ -10,8 +10,6 @@ export default function Topbar({
   availableLines,
   totalLines,
   onClearAll,
-  onUndo,
-  canUndo,
   onArchiveToday,
   onOpenClient,
   onOpenPrint,
@@ -24,6 +22,9 @@ export default function Topbar({
   leadModeActive = false,
   onLeadMode,
   onLeadModeOff,
+
+  // Undo panel slot
+  undoSlot,
 }) {
   const [clearOpen, setClearOpen] = useState(false);
   const [clearModalKey, setClearModalKey] = useState(0);
@@ -65,15 +66,7 @@ export default function Topbar({
             Client
           </button>
 
-          <button
-            className="button"
-            type="button"
-            onClick={onUndo}
-            disabled={!canUndo}
-            title={!canUndo ? "Nothing to undo" : "Undo last action"}
-          >
-            Undo
-          </button>
+          {undoSlot}
 
           {/*   popup button */}
           {/* <button

--- a/src/app/components/ropes/UndoHistoryPanel.jsx
+++ b/src/app/components/ropes/UndoHistoryPanel.jsx
@@ -1,0 +1,201 @@
+// src/app/top/components/UndoHistoryPanel.jsx
+"use client";
+
+import { useEffect, useLayoutEffect, useRef, useState } from "react";
+
+const DROPDOWN_WIDTH = 340;
+const VIEWPORT_MARGIN = 12;
+
+function fmtRelative(ts) {
+  const now = Date.now();
+  const diff = Math.max(0, now - Number(ts || now));
+  const secs = Math.floor(diff / 1000);
+  if (secs < 60) return `${secs}s ago`;
+  const mins = Math.floor(secs / 60);
+  if (mins < 60) return `${mins}m ago`;
+  const hrs = Math.floor(mins / 60);
+  return `${hrs}h ago`;
+}
+
+export default function UndoHistoryPanel({ actions = [], onUndo, onClear }) {
+  const [open, setOpen] = useState(false);
+  const [undoing, setUndoing] = useState(null);
+  const [pos, setPos] = useState({ top: 0, left: 0, width: DROPDOWN_WIDTH });
+  const wrapRef = useRef(null);
+  const dropRef = useRef(null);
+
+  const count = actions.length;
+
+  // Close on outside click
+  useEffect(() => {
+    if (!open) return;
+    const onDown = (e) => {
+      if (
+        wrapRef.current &&
+        !wrapRef.current.contains(e.target) &&
+        dropRef.current &&
+        !dropRef.current.contains(e.target)
+      ) {
+        setOpen(false);
+      }
+    };
+    document.addEventListener("mousedown", onDown);
+    document.addEventListener("touchstart", onDown);
+    return () => {
+      document.removeEventListener("mousedown", onDown);
+      document.removeEventListener("touchstart", onDown);
+    };
+  }, [open]);
+
+  // Position the dropdown relative to the button, clamped to viewport
+  useLayoutEffect(() => {
+    if (!open) return;
+    const btn = wrapRef.current;
+    if (!btn) return;
+
+    const recalc = () => {
+      const rect = btn.getBoundingClientRect();
+      const viewportW = window.innerWidth;
+      const width = Math.min(DROPDOWN_WIDTH, viewportW - VIEWPORT_MARGIN * 2);
+
+      // Try left-align with button first; if it'd overflow right, clamp.
+      let left = rect.left;
+      if (left + width + VIEWPORT_MARGIN > viewportW) {
+        left = viewportW - width - VIEWPORT_MARGIN;
+      }
+      if (left < VIEWPORT_MARGIN) left = VIEWPORT_MARGIN;
+
+      const top = rect.bottom + 6;
+      setPos({ top, left, width });
+    };
+
+    recalc();
+    window.addEventListener("resize", recalc);
+    window.addEventListener("scroll", recalc, true);
+    return () => {
+      window.removeEventListener("resize", recalc);
+      window.removeEventListener("scroll", recalc, true);
+    };
+  }, [open]);
+
+  async function handleUndo(id) {
+    if (undoing) return;
+    setUndoing(id);
+    try {
+      await onUndo(id);
+    } finally {
+      setUndoing(null);
+    }
+  }
+
+  return (
+    <>
+      <div
+        ref={wrapRef}
+        style={{ position: "relative", display: "inline-block" }}
+      >
+        <button
+          type="button"
+          className="button"
+          onClick={() => setOpen((v) => !v)}
+          disabled={count === 0}
+          style={{
+            fontSize: 13,
+            padding: "6px 10px",
+            opacity: count === 0 ? 0.5 : 1,
+          }}
+          title={
+            count === 0
+              ? "No recent actions"
+              : `${count} recent action${count === 1 ? "" : "s"}`
+          }
+        >
+          ↶ Undo {count > 0 ? `(${count})` : ""}
+        </button>
+      </div>
+
+      {open && count > 0 && (
+        <div
+          ref={dropRef}
+          className="card"
+          style={{
+            position: "fixed",
+            top: pos.top,
+            left: pos.left,
+            width: pos.width,
+            zIndex: 1000,
+            maxHeight: "min(420px, 70vh)",
+            overflowY: "auto",
+            padding: 10,
+            boxShadow: "var(--shadow-md)",
+          }}
+        >
+          <div
+            style={{
+              display: "flex",
+              justifyContent: "space-between",
+              alignItems: "center",
+              marginBottom: 8,
+            }}
+          >
+            <div style={{ fontWeight: 700, fontSize: 14 }}>Recent Actions</div>
+            <button
+              type="button"
+              className="button"
+              onClick={() => {
+                onClear();
+                setOpen(false);
+              }}
+              style={{ fontSize: 11, padding: "4px 8px", minHeight: 0 }}
+            >
+              Clear
+            </button>
+          </div>
+
+          <div style={{ display: "flex", flexDirection: "column", gap: 6 }}>
+            {actions.map((a, idx) => (
+              <div
+                key={a.id}
+                className="item"
+                style={{
+                  padding: 8,
+                  display: "flex",
+                  justifyContent: "space-between",
+                  alignItems: "center",
+                  gap: 8,
+                  borderRadius: 8,
+                }}
+              >
+                <div style={{ flex: 1, minWidth: 0 }}>
+                  <div
+                    style={{
+                      fontSize: 13,
+                      fontWeight: idx === 0 ? 700 : 500,
+                      overflow: "hidden",
+                      textOverflow: "ellipsis",
+                      whiteSpace: "nowrap",
+                    }}
+                  >
+                    {a.description}
+                  </div>
+                  <div className="muted" style={{ fontSize: 11 }}>
+                    {fmtRelative(a.timestamp)}
+                  </div>
+                </div>
+                <button
+                  className="button button-primary"
+                  type="button"
+                  onClick={() => handleUndo(a.id)}
+                  disabled={Boolean(undoing)}
+                  style={{ fontSize: 12, padding: "6px 10px", minHeight: 0 }}
+                >
+                  {undoing === a.id ? "..." : "Undo"}
+                </button>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+    </>
+  );
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1197,9 +1197,13 @@ body {
   width: 100%;
 }
 
+.topbarStatus,
 .topbarStatusCard {
   margin-left: auto; /* push to the right */
   min-width: 320px;
+  display: grid;
+  grid-template-columns: repeat(6, minmax(0, 1fr));
+  gap: 10px;
 }
 
 /* stack at 900px and below */
@@ -1208,14 +1212,20 @@ body {
     flex-direction: column;
   }
 
+  .topbarStatus,
   .topbarStatusCard {
     margin-left: 0;
     width: 100%;
+    min-width: 0;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
   }
 }
-@media (max-width: 900px) {
+
+/* phones: 2 columns */
+@media (max-width: 520px) {
+  .topbarStatus,
   .topbarStatusCard {
-    grid-template-columns: repeat(3, minmax(0, 1fr)) !important;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 }
 

--- a/src/app/lib/useUndoHistory.js
+++ b/src/app/lib/useUndoHistory.js
@@ -1,0 +1,64 @@
+// src/app/top/lib/useUndoHistory.js
+"use client";
+
+import { useCallback, useRef, useState } from "react";
+
+const MAX_HISTORY = 10;
+
+/**
+ * Undo history for top-page actions.
+ * Stores up to MAX_HISTORY actions in memory.
+ * Each action carries a reverse() closure that re-applies the prior state via the API.
+ */
+export default function useUndoHistory() {
+  const [actions, setActions] = useState([]);
+  const actionsRef = useRef([]);
+  const busyRef = useRef(false);
+
+  const sync = useCallback((next) => {
+    actionsRef.current = next;
+    setActions(next);
+  }, []);
+
+  const pushAction = useCallback(
+    (action) => {
+      const full = {
+        id:
+          typeof crypto !== "undefined" && crypto.randomUUID
+            ? crypto.randomUUID()
+            : `a-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+        timestamp: Date.now(),
+        ...action,
+      };
+      const next = [full, ...actionsRef.current].slice(0, MAX_HISTORY);
+      sync(next);
+    },
+    [sync],
+  );
+
+  const undo = useCallback(
+    async (actionId) => {
+      if (busyRef.current) return { ok: false, error: "Busy" };
+      const target = actionsRef.current.find((a) => a.id === actionId);
+      if (!target) return { ok: false, error: "Action not found" };
+
+      busyRef.current = true;
+      try {
+        if (typeof target.reverse === "function") {
+          await target.reverse();
+        }
+        sync(actionsRef.current.filter((a) => a.id !== actionId));
+        return { ok: true };
+      } catch (e) {
+        return { ok: false, error: e?.message || "Undo failed" };
+      } finally {
+        busyRef.current = false;
+      }
+    },
+    [sync],
+  );
+
+  const clear = useCallback(() => sync([]), [sync]);
+
+  return { actions, pushAction, undo, clear };
+}

--- a/src/app/page.js
+++ b/src/app/page.js
@@ -10,8 +10,6 @@ import {
   saveEntries,
   uid,
   subscribeToRopesStorage,
-  loadUndoStack,
-  saveUndoStack,
   archiveToday,
   loadStaffAuthedAt,
   setStaffAuthedNow,
@@ -23,6 +21,8 @@ import {
 } from "@/app/lib/ropesStore";
 
 import Topbar from "@/app/components/ropes/Topbar";
+import UndoHistoryPanel from "@/app/components/ropes/UndoHistoryPanel";
+import useUndoHistory from "@/app/lib/useUndoHistory";
 import QuickQuote from "@/app/components/ropes/QuickQuote";
 import AddGuestForm from "@/app/components/ropes/AddGuestForm";
 import UpNowList from "@/app/components/ropes/UpNowList";
@@ -291,7 +291,7 @@ export default function Home() {
 
   const [now, setNow] = useState(() => new Date());
 
-  const [undoStack, setUndoStack] = useState(() => loadUndoStack());
+  const undoHistory = useUndoHistory();
 
   // reservations popup
   const [reservationsOpen, setReservationsOpen] = useState(false);
@@ -355,7 +355,6 @@ export default function Home() {
   const refreshFromLocal = () => {
     setSettings(loadSettings());
     setEntries(ensureQueueOrderList(loadEntries()));
-    setUndoStack(loadUndoStack());
   };
 
   const createLockRef = useRef(false);
@@ -547,28 +546,23 @@ export default function Home() {
     } catch {}
   }, [entries]);
 
-  function pushUndoSnapshot(prevEntries) {
-    const snap = {
-      at: new Date().toISOString(),
-      entries: Array.isArray(prevEntries) ? prevEntries : [],
+  // Helper to create a CREATE_ENTRY payload from a live-entry snapshot
+  function entryToCreatePayload(e) {
+    return {
+      id: e.id,
+      name: e.name,
+      party_size: e.partySize,
+      lines_used: e.linesUsed ?? e.partySize,
+      phone: e.phone ?? null,
+      notes: e.notes ?? null,
+      status: e.status ?? "WAITING",
+      course_phase: e.coursePhase ?? null,
+      queue_order: e.queueOrder ?? null,
+      assigned_tag: e.assignedTag ?? null,
+      sent_up_at: e.sentUpAt ?? null,
+      started_at: e.startedAt ?? null,
+      created_at: e.createdAt ?? null,
     };
-    setUndoStack((prev) => {
-      const next = [snap, ...(Array.isArray(prev) ? prev : [])].slice(0, 20);
-      saveUndoStack(next);
-      return next;
-    });
-  }
-
-  function undoLast() {
-    setUndoStack((prev) => {
-      if (!prev || prev.length === 0) return prev;
-      const [top, ...rest] = prev;
-      if (top?.entries) {
-        setEntries(ensureQueueOrderList(top.entries));
-      }
-      saveUndoStack(rest);
-      return rest;
-    });
   }
 
   const waiting = useMemo(() => {
@@ -831,7 +825,7 @@ export default function Home() {
 
       // optimistic local
       setEntries((prev) => {
-        pushUndoSnapshot(prev);
+        /* undo now handled via useUndoHistory */
         const next = [
           ...prev,
           {
@@ -869,6 +863,15 @@ export default function Home() {
         });
 
         setRemoteOnline(true);
+
+        undoHistory.pushAction({
+          type: "ADD",
+          description: `Added ${name}`,
+          reverse: async () => {
+            await statePut({ op: "DELETE_ENTRY", payload: { id: localId } });
+            refreshFromServer();
+          },
+        });
       } catch (err) {
         console.error("CREATE_ENTRY failed:", err);
         setRemoteOnline(false);
@@ -923,6 +926,17 @@ export default function Home() {
       return;
     }
 
+    // Snapshot prior state for undo
+    const prevPatch = {
+      status: front.status ?? "WAITING",
+      partySize: front.partySize,
+      linesUsed: front.linesUsed ?? front.partySize,
+      startedAt: front.startedAt ?? null,
+      sentUpAt: front.sentUpAt ?? null,
+      coursePhase: front.coursePhase ?? null,
+      endTime: front.endTime ?? null,
+    };
+
     const nowISO = new Date().toISOString();
     const patch = {
       status: "UP",
@@ -935,7 +949,6 @@ export default function Home() {
     };
 
     setEntries((prev) => {
-      pushUndoSnapshot(prev);
       return prev.map((e) =>
         String(e.id) !== String(id) ? e : { ...e, ...patch },
       );
@@ -947,6 +960,18 @@ export default function Home() {
         payload: { id, patch: toDbPatchFromUi(patch) },
       });
       setRemoteOnline(true);
+
+      undoHistory.pushAction({
+        type: "SEND_UP",
+        description: `Sent up ${front.name || "group"}`,
+        reverse: async () => {
+          await statePut({
+            op: "PATCH_ENTRY",
+            payload: { id, patch: toDbPatchFromUi(prevPatch) },
+          });
+          refreshFromServer();
+        },
+      });
     } catch (err) {
       console.error("PATCH_ENTRY (startGroup) failed:", err);
       setRemoteOnline(false);
@@ -955,9 +980,11 @@ export default function Home() {
   }
 
   async function completeGroup(id) {
+    const snap = entriesRef.current.find((e) => String(e.id) === String(id));
+    if (!snap) return;
+
     // optimistic local
     setEntries((prev) => {
-      pushUndoSnapshot(prev);
       return prev.map((e) =>
         String(e.id) === String(id)
           ? { ...e, status: "DONE", linesUsed: 0 }
@@ -967,11 +994,33 @@ export default function Home() {
 
     // move to history so it disappears from live table too
     try {
-      await statePut({
+      const resp = await statePut({
         op: "MOVE_TO_HISTORY",
         payload: { id, status: "DONE", finish_reason: "Finished (bottom)" },
       });
       setRemoteOnline(true);
+
+      const historyId = resp?.history_id || null;
+
+      undoHistory.pushAction({
+        type: "FINISH",
+        description: `Finished ${snap.name || "group"}`,
+        reverse: async () => {
+          await statePut({
+            op: "CREATE_ENTRY",
+            payload: entryToCreatePayload(snap),
+          });
+          if (historyId) {
+            try {
+              await statePut({
+                op: "DELETE_FROM_HISTORY",
+                payload: { id: historyId },
+              });
+            } catch {}
+          }
+          refreshFromServer();
+        },
+      });
     } catch (err) {
       console.error("MOVE_TO_HISTORY (completeGroup) failed:", err);
       setRemoteOnline(false);
@@ -980,14 +1029,29 @@ export default function Home() {
   }
 
   async function remove(id) {
+    const snap = entriesRef.current.find((e) => String(e.id) === String(id));
+
     setEntries((prev) => {
-      pushUndoSnapshot(prev);
       return prev.filter((e) => String(e.id) !== String(id));
     });
 
     try {
       await statePut({ op: "DELETE_ENTRY", payload: { id } });
       setRemoteOnline(true);
+
+      if (snap) {
+        undoHistory.pushAction({
+          type: "REMOVE",
+          description: `Removed ${snap.name || "group"}`,
+          reverse: async () => {
+            await statePut({
+              op: "CREATE_ENTRY",
+              payload: entryToCreatePayload(snap),
+            });
+            refreshFromServer();
+          },
+        });
+      }
     } catch (err) {
       console.error("DELETE_ENTRY failed:", err);
       setRemoteOnline(false);
@@ -997,7 +1061,7 @@ export default function Home() {
 
   async function clearAll() {
     setEntries((prev) => {
-      pushUndoSnapshot(prev);
+      /* undo now handled via useUndoHistory */
       return [];
     });
 
@@ -1046,7 +1110,7 @@ export default function Home() {
     ) {
       // normalize locally then let them click again (prevents 0/0 no-op swaps)
       setEntries((prev) => {
-        pushUndoSnapshot(prev);
+        /* undo now handled via useUndoHistory */
         return ensureQueueOrderList(prev);
       });
       fireToast("Order normalized — try again", "info");
@@ -1058,7 +1122,7 @@ export default function Home() {
 
     // optimistic local swap
     setEntries((prev) => {
-      pushUndoSnapshot(prev);
+      /* undo now handled via useUndoHistory */
       const next = prev.map((e) => {
         const eid = String(e.id);
         if (eid === String(swappedA.id))
@@ -1088,6 +1152,30 @@ export default function Home() {
         }),
       ]);
       setRemoteOnline(true);
+
+      undoHistory.pushAction({
+        type: "REORDER",
+        description: `Moved ${a.name || "group"} ${direction === "UP" ? "up" : "down"}`,
+        reverse: async () => {
+          await Promise.all([
+            statePut({
+              op: "PATCH_ENTRY",
+              payload: {
+                id: a.id,
+                patch: toDbPatchFromUi({ queueOrder: aOrder }),
+              },
+            }),
+            statePut({
+              op: "PATCH_ENTRY",
+              payload: {
+                id: b.id,
+                patch: toDbPatchFromUi({ queueOrder: bOrder }),
+              },
+            }),
+          ]);
+          refreshFromServer();
+        },
+      });
     } catch (err) {
       console.error("PATCH_ENTRY (moveWaiting) failed:", err);
       setRemoteOnline(false);
@@ -1146,7 +1234,7 @@ export default function Home() {
 
         if (!changed) return prev;
 
-        pushUndoSnapshot(prev);
+        /* undo now handled via useUndoHistory */
 
         if (transitioned.length) {
           Promise.all(
@@ -1188,8 +1276,22 @@ export default function Home() {
 
     const coerced = { ...updated, partySize, linesUsed };
 
+    // Snapshot prior state for undo
+    const before = entriesRef.current.find(
+      (e) => String(e.id) === String(coerced.id),
+    );
+    const prevPatch = before
+      ? {
+          name: before.name,
+          ...(!isUp ? { partySize: before.partySize } : {}),
+          phone: before.phone,
+          notes: before.notes,
+          linesUsed: before.linesUsed,
+          assignedTag: before.assignedTag ?? null,
+        }
+      : null;
+
     setEntries((prev) => {
-      pushUndoSnapshot(prev);
       return prev.map((e) =>
         String(e.id) === String(coerced.id) ? coerced : e,
       );
@@ -1221,6 +1323,20 @@ export default function Home() {
 
       await statePut({ op: "PATCH_ENTRY", payload: { id: coerced.id, patch } });
       setRemoteOnline(true);
+
+      if (prevPatch) {
+        undoHistory.pushAction({
+          type: "EDIT",
+          description: `Edited ${before.name || "group"}`,
+          reverse: async () => {
+            await statePut({
+              op: "PATCH_ENTRY",
+              payload: { id: coerced.id, patch: toDbPatchFromUi(prevPatch) },
+            });
+            refreshFromServer();
+          },
+        });
+      }
     } catch (err) {
       console.error("PATCH_ENTRY (saveEdit) failed:", err);
       setRemoteOnline(false);
@@ -1331,8 +1447,6 @@ export default function Home() {
         availableLines={availableLines}
         totalLines={settings.totalLines}
         onClearAll={clearAll}
-        onUndo={undoLast}
-        canUndo={undoStack.length > 0}
         onArchiveToday={doArchiveToday}
         onOpenClient={openClient}
         onOpenPrint={openPrint}
@@ -1341,6 +1455,21 @@ export default function Home() {
         leadModeActive={leadModeActive}
         onLeadMode={() => setLeadPinOpen(true)}
         onLeadModeOff={() => setLeadModeActive(false)}
+        undoSlot={
+          <UndoHistoryPanel
+            actions={undoHistory.actions}
+            onUndo={async (id) => {
+              const res = await undoHistory.undo(id);
+              if (res?.ok) {
+                fireToast("Undone", "success");
+                refreshFromServer();
+              } else {
+                fireToast(res?.error || "Undo failed", "warning");
+              }
+            }}
+            onClear={undoHistory.clear}
+          />
+        }
       />
 
       <FlowPausedBanner settings={settings} />

--- a/src/app/top/components/EditGroupModal.jsx
+++ b/src/app/top/components/EditGroupModal.jsx
@@ -4,6 +4,7 @@ export default function EditGroupModal({
   setEditDraft,
   closeEdit,
   saveEdit,
+  tagOptions = [],
 }) {
   if (!open) return null;
 
@@ -105,6 +106,32 @@ export default function EditGroupModal({
                   setEditDraft((d) => ({ ...d, notes: e.target.value }))
                 }
               />
+            </div>
+          </div>
+
+          <div
+            className="row"
+            style={{ gap: 12, marginTop: 12, flexWrap: "wrap" }}
+          >
+            <div style={{ flex: "1 1 260px" }}>
+              <div className="muted" style={{ fontSize: 13, marginBottom: 6 }}>
+                Group Tag
+              </div>
+              <select
+                className="input"
+                style={{ width: "100%", padding: 10 }}
+                value={editDraft.assignedTag ?? ""}
+                onChange={(e) =>
+                  setEditDraft((d) => ({ ...d, assignedTag: e.target.value }))
+                }
+              >
+                <option value="">No tag</option>
+                {tagOptions.map((t) => (
+                  <option key={t} value={t}>
+                    {t}
+                  </option>
+                ))}
+              </select>
             </div>
           </div>
 

--- a/src/app/top/components/TopHeader.jsx
+++ b/src/app/top/components/TopHeader.jsx
@@ -9,6 +9,7 @@ export default function TopHeader({
   courseCount,
   waitingCount,
   settings,
+  undoSlot,
 }) {
   return (
     <div className="topbar">
@@ -42,17 +43,14 @@ export default function TopHeader({
 
           {/* ✅ pass DB-backed settings down */}
           <FlowControlButton className="button" settings={settings} />
+
+          {undoSlot}
         </div>
 
         {/* RIGHT: Status cards */}
         <div
           className="card topbarStatus"
-          style={{
-            padding: 12,
-            display: "grid",
-            gridTemplateColumns: "repeat(6, minmax(0, 1fr))",
-            gap: 10,
-          }}
+          style={{ padding: 12 }}
         >
           <div className="item" style={{ padding: 10 }}>
             <div className="muted" style={{ fontSize: 13 }}>

--- a/src/app/top/page.jsx
+++ b/src/app/top/page.jsx
@@ -23,6 +23,8 @@ import OperatorNotesSection from "./components/OperatorNotesSection";
 import EditGroupModal from "./components/EditGroupModal";
 import SplitGroupModal from "./components/SplitGroupModal";
 import TopSoundController from "@/app/components/ropes/TopSoundController";
+import UndoHistoryPanel from "@/app/components/ropes/UndoHistoryPanel";
+import useUndoHistory from "@/app/lib/useUndoHistory";
 
 import {
   entryTintStyle,
@@ -196,6 +198,9 @@ export default function TopRopesPage() {
 
   // Split modal state
   const [splitEntry, setSplitEntry] = useState(null);
+
+  // Undo history
+  const undoHistory = useUndoHistory();
 
   // Finish confirm
   const [finishConfirmOpen, setFinishConfirmOpen] = useState(false);
@@ -419,7 +424,20 @@ export default function TopRopesPage() {
   }
 
   function handleAssignTag(entryId, tag) {
-    patchEntryRemote(entryId, { assignedTag: tag || null });
+    const before = entries.find((e) => e.id === entryId);
+    const prevTag = before?.assignedTag ?? null;
+    const newTag = tag || null;
+    if (prevTag === newTag) return;
+
+    patchEntryRemote(entryId, { assignedTag: newTag });
+
+    undoHistory.pushAction({
+      type: "TAG",
+      description: `Set tag "${newTag || "none"}" on ${before?.name || "group"}`,
+      reverse: async () => {
+        await patchEntryRemote(entryId, { assignedTag: prevTag });
+      },
+    });
   }
 
   function handleStartCourse(entry) {
@@ -432,6 +450,14 @@ export default function TopRopesPage() {
     const linesNeeded = Math.max(1, Number(entry.partySize || 1));
     const nowISO = new Date().toISOString();
 
+    const prev = {
+      coursePhase: entry.coursePhase ?? null,
+      linesUsed: entry.linesUsed ?? null,
+      startedAt: entry.startedAt ?? null,
+      startTime: entry.startTime ?? null,
+      endTime: entry.endTime ?? null,
+    };
+
     patchEntryRemote(entry.id, {
       coursePhase: "ON_COURSE",
       linesUsed: Number.isFinite(Number(entry.linesUsed))
@@ -440,6 +466,14 @@ export default function TopRopesPage() {
       startedAt: entry.startedAt || nowISO,
       startTime: nowISO,
       endTime: isoPlusMinutes(TOP_MIN),
+    });
+
+    undoHistory.pushAction({
+      type: "START_COURSE",
+      description: `Started ${entry.name || "group"} on course`,
+      reverse: async () => {
+        await patchEntryRemote(entry.id, prev);
+      },
     });
   }
 
@@ -451,8 +485,17 @@ export default function TopRopesPage() {
     const base =
       currentEnd && !isNaN(currentEnd.getTime()) ? currentEnd : new Date();
     const nextEnd = new Date(base.getTime() + 5 * 60 * 1000).toISOString();
+    const prevEnd = entry.endTime;
 
     patchEntryRemote(entryId, { endTime: nextEnd });
+
+    undoHistory.pushAction({
+      type: "EXTEND",
+      description: `+5 min on ${entry.name || "group"}`,
+      reverse: async () => {
+        await patchEntryRemote(entryId, { endTime: prevEnd });
+      },
+    });
   }
 
   function openFinishConfirm(entry) {
@@ -471,11 +514,14 @@ export default function TopRopesPage() {
 
     setFinishSaving(true);
 
+    // Snapshot before removing (for undo)
+    const snap = { ...finishEntry };
+
     // optimistic local (remove)
     setEntries((prev) => prev.filter((e) => e.id !== finishEntry.id));
 
     try {
-      await statePut({
+      const resp = await statePut({
         op: "MOVE_TO_HISTORY",
         payload: {
           id: finishEntry.id,
@@ -486,6 +532,44 @@ export default function TopRopesPage() {
 
       setRemoteOnline(true);
       refreshFromServer();
+
+      const historyId = resp?.history_id || null;
+
+      undoHistory.pushAction({
+        type: "FINISH",
+        description: `Finished ${snap.name || "group"}`,
+        reverse: async () => {
+          // Recreate the entry in live with prior state
+          await statePut({
+            op: "CREATE_ENTRY",
+            payload: {
+              name: snap.name,
+              party_size: snap.partySize,
+              lines_used: snap.linesUsed ?? snap.partySize,
+              phone: snap.phone ?? null,
+              notes: snap.notes ?? null,
+              status: snap.status || "UP",
+              course_phase: snap.coursePhase || "ON_COURSE",
+              assigned_tag: snap.assignedTag ?? null,
+              sent_up_at: snap.sentUpAt ?? null,
+              started_at: snap.startedAt ?? null,
+              created_at: snap.createdAt ?? null,
+            },
+          });
+          // Clean up the history row we just created
+          if (historyId) {
+            try {
+              await statePut({
+                op: "DELETE_FROM_HISTORY",
+                payload: { id: historyId },
+              });
+            } catch {
+              // not fatal — live entry is restored regardless
+            }
+          }
+          refreshFromServer();
+        },
+      });
     } catch {
       setRemoteOnline(false);
       showToast("Finished locally — couldn’t sync", "warning");
@@ -510,16 +594,29 @@ export default function TopRopesPage() {
       partySize: String(entry.linesUsed ?? entry.partySize ?? ""),
       phone: String(entry.phone ?? ""),
       notes: String(entry.notes ?? ""),
+      assignedTag: String(entry.assignedTag ?? ""),
     });
   }
 
   function closeEdit() {
     setEditingId(null);
-    setEditDraft({ name: "", partySize: "", phone: "", notes: "" });
+    setEditDraft({
+      name: "",
+      partySize: "",
+      phone: "",
+      notes: "",
+      assignedTag: "",
+    });
   }
 
   async function saveEdit() {
     if (!editingId) return;
+
+    const before = entries.find((e) => e.id === editingId);
+    if (!before) {
+      closeEdit();
+      return;
+    }
 
     const name = String(editDraft.name || "")
       .trim()
@@ -534,6 +631,15 @@ export default function TopRopesPage() {
     const notes = String(editDraft.notes || "")
       .trim()
       .slice(0, 120);
+    const assignedTag = String(editDraft.assignedTag || "").trim() || null;
+
+    const prev = {
+      name: before.name ?? "",
+      linesUsed: before.linesUsed ?? null,
+      phone: before.phone ?? "",
+      notes: before.notes ?? "",
+      assignedTag: before.assignedTag ?? null,
+    };
 
     // Only update linesUsed — never overwrite partySize so analytics always
     // records the original registered group size, not an operational adjustment
@@ -542,6 +648,15 @@ export default function TopRopesPage() {
       linesUsed: linesUsedNum,
       phone,
       notes,
+      assignedTag,
+    });
+
+    undoHistory.pushAction({
+      type: "EDIT",
+      description: `Edited ${before.name || "group"}`,
+      reverse: async () => {
+        await patchEntryRemote(editingId, prev);
+      },
     });
 
     showToast("Saved", "success");
@@ -663,6 +778,46 @@ export default function TopRopesPage() {
 
       setRemoteOnline(true);
       clearMerge();
+
+      // Capture full snapshots for undo
+      const primarySnapshot = {
+        party_size: a.partySize,
+        lines_used: a.linesUsed ?? a.partySize,
+        notes: a.notes ?? null,
+        merge_history: null,
+      };
+      const secondarySnapshot = {
+        name: b.name,
+        party_size: b.partySize,
+        lines_used: b.linesUsed ?? b.partySize,
+        phone: b.phone ?? null,
+        notes: b.notes ?? null,
+        status: b.status ?? "UP",
+        course_phase: b.coursePhase ?? "SENT",
+        assigned_tag: b.assignedTag ?? null,
+        sent_up_at: b.sentUpAt ?? null,
+        started_at: b.startedAt ?? null,
+        created_at: b.createdAt ?? null,
+      };
+
+      undoHistory.pushAction({
+        type: "MERGE",
+        description: `Merged ${a.name} + ${b.name}`,
+        reverse: async () => {
+          // Restore primary’s pre-merge state and recreate secondary
+          await Promise.all([
+            statePut({
+              op: "PATCH_ENTRY",
+              payload: { id: primaryId, patch: primarySnapshot },
+            }),
+            statePut({
+              op: "CREATE_ENTRY",
+              payload: secondarySnapshot,
+            }),
+          ]);
+          refreshFromServer();
+        },
+      });
     } catch {
       setRemoteOnline(false);
       showToast("Merged locally — couldn’t sync", "warning");
@@ -682,6 +837,21 @@ export default function TopRopesPage() {
     if (!entry?.id || !groupSizes?.length) return;
 
     const parentName = entry.name || "Group";
+
+    // Snapshot original for undo
+    const originalSnapshot = {
+      name: entry.name,
+      party_size: entry.partySize,
+      lines_used: entry.linesUsed ?? entry.partySize,
+      phone: entry.phone ?? null,
+      notes: entry.notes ?? null,
+      status: entry.status ?? "UP",
+      course_phase: entry.coursePhase ?? "SENT",
+      assigned_tag: entry.assignedTag ?? null,
+      sent_up_at: entry.sentUpAt ?? null,
+      started_at: entry.startedAt ?? null,
+      created_at: entry.createdAt ?? null,
+    };
 
     // Create sub-group entries, delete the original
     // Each sub-group inherits the parent's sent-up state
@@ -730,14 +900,36 @@ export default function TopRopesPage() {
     });
 
     try {
-      await Promise.all([
+      const results = await Promise.all([
         ...createOps,
         statePut({ op: "DELETE_ENTRY", payload: { id: entry.id } }),
       ]);
+      // First N results are the create responses; last is the delete
+      const createdIds = results
+        .slice(0, groupSizes.length)
+        .map((r) => r?.entry?.id)
+        .filter(Boolean);
+
       setRemoteOnline(true);
       closeSplit();
       showToast(`Split into ${groupSizes.length} groups`, "success");
       refreshFromServer();
+
+      undoHistory.pushAction({
+        type: "SPLIT",
+        description: `Split ${parentName} into ${groupSizes.length} groups`,
+        reverse: async () => {
+          // Delete the sub-groups and recreate the original
+          const deleteOps = createdIds.map((id) =>
+            statePut({ op: "DELETE_ENTRY", payload: { id } }),
+          );
+          await Promise.all([
+            ...deleteOps,
+            statePut({ op: "CREATE_ENTRY", payload: originalSnapshot }),
+          ]);
+          refreshFromServer();
+        },
+      });
     } catch {
       setRemoteOnline(false);
       showToast("Split locally — couldn't sync", "warning");
@@ -852,6 +1044,21 @@ export default function TopRopesPage() {
         remoteOnline={remoteOnline}
         onPauseFlow={pauseFlow}
         onResumeFlow={resumeFlow}
+        undoSlot={
+          <UndoHistoryPanel
+            actions={undoHistory.actions}
+            onUndo={async (id) => {
+              const res = await undoHistory.undo(id);
+              if (res?.ok) {
+                showToast("Undone", "success");
+                refreshFromServer();
+              } else {
+                showToast(res?.error || "Undo failed", "warning");
+              }
+            }}
+            onClear={undoHistory.clear}
+          />
+        }
       />
 
       <div className="topBody">
@@ -928,6 +1135,11 @@ export default function TopRopesPage() {
         setEditDraft={setEditDraft}
         closeEdit={closeEdit}
         saveEdit={saveEdit}
+        tagOptions={
+          editingId
+            ? tagOptionsForEntry(entries.find((e) => e.id === editingId))
+            : []
+        }
       />
 
       <SplitGroupModal


### PR DESCRIPTION
## Summary

- Undo history — Last 10 actions tracked on both top and bottom pages with per-action undo (compact dropdown with smart positioning to avoid iPad clipping)
- Tag editing after start — Group tag is now editable in the Edit modal even after the course has started
- Advanced search — New /analytics/advanced page to look up past groups by name, phone, group size, date, and time range
- Merge history tracking — Original group data preserved when merging; visible on top, bottom, and in advanced search
- Split groups — Break a large group into smaller waves with their own tags and timers
- Send-up sound notification — Top page plays a jingle when bottom sends a guest up; persists "enabled" state across refreshes
- Mobile responsive — Fixed TopHeader status grid CSS and made Advanced Search + Analytics grids auto-fit

## Test plan

- [ ] Top page: send-up from bottom triggers sound; undo dropdown positions correctly on iPad
- [ ] Top page: edit a group's tag while on course
- [ ] Top page: merge groups, verify originals visible in expandable badge
- [ ] Top page: split a 15-person group into waves, each gets own tag/timer
- [ ] Top page: undo works for start course, tag, edit, extend, merge, split, finish
- [ ] Bottom page: undo works for add, send up, finish, remove, reorder, edit
- [ ] Advanced Search: filter by date + time range + group size
- [ ] Mobile: layouts stack at <520px