### PR TITLE
Fix decimals, merged archive, and header counts (#37, #35, #39)

### DIFF
--- a/src/app/archive/page.jsx
+++ b/src/app/archive/page.jsx
@@ -144,6 +144,53 @@ export default function ArchivePage() {
                     </div>
                   ) : null}
 
+                  {Array.isArray(e.mergeHistory) && e.mergeHistory.length > 0 ? (
+                    <div style={{ marginTop: 10 }}>
+                      <div className="muted" style={{ fontSize: 12 }}>
+                        Original Groups (before merge)
+                      </div>
+                      <div
+                        style={{
+                          marginTop: 6,
+                          padding: 10,
+                          background: "var(--color-bg)",
+                          borderRadius: 10,
+                          border: "1px solid var(--color-border)",
+                          display: "flex",
+                          flexDirection: "column",
+                          gap: 8,
+                        }}
+                      >
+                        {e.mergeHistory.map((g, i) => (
+                          <div key={g.id || i}>
+                            <div style={{ fontWeight: 700 }}>
+                              {g.name || "—"}{" "}
+                              <span
+                                className="muted"
+                                style={{ fontWeight: 400 }}
+                              >
+                                — group of {g.partySize || "?"}
+                              </span>
+                            </div>
+                            <div
+                              className="muted"
+                              style={{ fontSize: 12, marginTop: 2 }}
+                            >
+                              Phone:{" "}
+                              <strong>
+                                {g.phone && g.phone !== "0"
+                                  ? g.phone
+                                  : "No phone"}
+                              </strong>
+                              {g.assignedTag ? ` • Tag: ${g.assignedTag}` : ""}
+                              {g.notes ? ` • Notes: ${g.notes}` : ""}
+                            </div>
+                          </div>
+                        ))}
+                      </div>
+                    </div>
+                  ) : null}
+
                   {Array.isArray(guestNotes) && guestNotes.length ? (
                     <div style={{ marginTop: 12 }}>
                       <div className="muted" style={{ fontSize: 12 }}>

--- a/src/app/lib/ropesStore.js
+++ b/src/app/lib/ropesStore.js
@@ -594,6 +594,7 @@ export async function archiveFlaggedEntry({
       startedAt: target.startedAt ?? null,
       assignedTag: target.assignedTag ?? null,
       queueOrder: target.queueOrder ?? null,
+      mergeHistory: Array.isArray(target.mergeHistory) ? target.mergeHistory : null,
     },
     guestNotes: Array.isArray(guestNotes) ? guestNotes : [],
   };

--- a/src/app/top/components/EditGroupModal.jsx
+++ b/src/app/top/components/EditGroupModal.jsx
@@ -63,15 +63,19 @@ export default function EditGroupModal({
               </div>
               <input
                 className="input"
+                type="number"
+                min="1"
+                max="20"
+                step="1"
                 style={{ width: "100%", padding: 10 }}
                 value={editDraft.partySize}
-                onChange={(e) =>
-                  setEditDraft((d) => ({
-                    ...d,
-                    partySize: e.target.value,
-                  }))
-                }
+                onChange={(e) => {
+                  // Strip any non-digit characters (blocks decimals/negatives)
+                  const raw = String(e.target.value || "").replace(/\D/g, "");
+                  setEditDraft((d) => ({ ...d, partySize: raw }));
+                }}
                 inputMode="numeric"
+                pattern="[0-9]*"
               />
             </div>
           </div>

--- a/src/app/top/components/TopHeader.jsx
+++ b/src/app/top/components/TopHeader.jsx
@@ -8,6 +8,9 @@ export default function TopHeader({
   sentCount,
   courseCount,
   waitingCount,
+  sentPeople = 0,
+  coursePeople = 0,
+  waitingPeople = 0,
   settings,
   undoSlot,
 }) {
@@ -74,21 +77,45 @@ export default function TopHeader({
             <div className="muted" style={{ fontSize: 13 }}>
               Coming Up
             </div>
-            <div style={{ fontSize: 16, fontWeight: 700 }}>{sentCount}</div>
+            <div style={{ fontSize: 16, fontWeight: 700 }}>
+              {sentCount}{" "}
+              <span
+                className="muted"
+                style={{ fontSize: 12, fontWeight: 500 }}
+              >
+                · {sentPeople}p
+              </span>
+            </div>
           </div>
 
           <div className="item" style={{ padding: 10 }}>
             <div className="muted" style={{ fontSize: 13 }}>
               On Course
             </div>
-            <div style={{ fontSize: 16, fontWeight: 700 }}>{courseCount}</div>
+            <div style={{ fontSize: 16, fontWeight: 700 }}>
+              {courseCount}{" "}
+              <span
+                className="muted"
+                style={{ fontSize: 12, fontWeight: 500 }}
+              >
+                · {coursePeople}p
+              </span>
+            </div>
           </div>
 
           <div className="item" style={{ padding: 10 }}>
             <div className="muted" style={{ fontSize: 13 }}>
               Waiting
             </div>
-            <div style={{ fontSize: 16, fontWeight: 700 }}>{waitingCount}</div>
+            <div style={{ fontSize: 16, fontWeight: 700 }}>
+              {waitingCount}{" "}
+              <span
+                className="muted"
+                style={{ fontSize: 12, fontWeight: 500 }}
+              >
+                · {waitingPeople}p
+              </span>
+            </div>
           </div>
 
           <div className="item" style={{ padding: 10 }}>

--- a/src/app/top/page.jsx
+++ b/src/app/top/page.jsx
@@ -623,7 +623,7 @@ export default function TopRopesPage() {
       .slice(0, 40);
     const linesUsedNum = Math.max(
       1,
-      Math.min(20, Number(editDraft.partySize || 1)),
+      Math.min(20, Math.floor(Number(editDraft.partySize || 1))),
     );
     const phone = String(editDraft.phone || "")
       .trim()
@@ -669,6 +669,16 @@ export default function TopRopesPage() {
   const sentCount = sentUp.length;
   const courseCount = onCourse.length;
   const waitingCount = waiting.length;
+
+  // People (sum of linesUsed / partySize) for each section
+  const sumPeople = (list) =>
+    list.reduce(
+      (n, e) => n + Math.max(1, Number(e.linesUsed ?? e.partySize ?? 1)),
+      0,
+    );
+  const sentPeople = sumPeople(sentUp);
+  const coursePeople = sumPeople(onCourse);
+  const waitingPeople = sumPeople(waiting);
 
   // ===== Merge =====
   function toggleMergeSelect(entryId) {
@@ -1040,6 +1050,9 @@ export default function TopRopesPage() {
         sentCount={sentCount}
         courseCount={courseCount}
         waitingCount={waitingCount}
+        sentPeople={sentPeople}
+        coursePeople={coursePeople}
+        waitingPeople={waitingPeople}
         settings={settings}
         remoteOnline={remoteOnline}
         onPauseFlow={pauseFlow}


### PR DESCRIPTION
- #37: Block decimal values in top edit modal Lines input (number type, step=1, strip non-digits, Math.floor on save)
- #35: Include mergeHistory in archived snapshot and render "Original Groups (before merge)" block on archive page
- #39: TopHeader Coming Up / On Course / Waiting now show both group count and people count